### PR TITLE
Add WAIaaS — self-hosted wallet daemon for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of Model Context Protocol (MCP) servers for cryptocurrency, block
 - **Blockscout** - [mcp-server](https://github.com/blockscout/mcp-server) - Wraps Blockscout APIs to expose blockchain data, balances, tokens, NFTs via MCP
 - **Web3 Assistant** - [web3-mcp-server](https://github.com/EmanuelJr/web3-mcp-server) - Secure interaction with blockchain smart contracts across multiple chains
 - **Strangelove Ventures** - [web3-mcp](https://github.com/strangelove-ventures/web3-mcp) - Interact with Solana, Ethereum, THORChain, XRP, TON, Cardano, and UTXO chains
+- **WAIaaS** - [WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS) - Self-hosted wallet daemon for AI agents. 59+ MCP tools for wallet management, DeFi, NFT, x402 across EVM + Solana. Default-deny policy engine, spending limits, kill switch
 
 ## DeFi & Trading
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A curated list of Model Context Protocol (MCP) servers for cryptocurrency, block
 - **Blockscout** - [mcp-server](https://github.com/blockscout/mcp-server) - Wraps Blockscout APIs to expose blockchain data, balances, tokens, NFTs via MCP
 - **Web3 Assistant** - [web3-mcp-server](https://github.com/EmanuelJr/web3-mcp-server) - Secure interaction with blockchain smart contracts across multiple chains
 - **Strangelove Ventures** - [web3-mcp](https://github.com/strangelove-ventures/web3-mcp) - Interact with Solana, Ethereum, THORChain, XRP, TON, Cardano, and UTXO chains
-- **WAIaaS** - [WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS) - Self-hosted wallet daemon for AI agents. 59+ MCP tools for wallet management, DeFi, NFT, x402 across EVM + Solana. Default-deny policy engine, spending limits, kill switch
+- **WAIaaS** - [WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS) [![WAIaaS MCP server](https://glama.ai/mcp/servers/minhoyoo-iotrust/WAIaaS/badges/score.svg)](https://glama.ai/mcp/servers/minhoyoo-iotrust/WAIaaS) - Self-hosted wallet daemon for AI agents. 60 MCP tools for wallet management, DeFi, NFT, x402 across EVM + Solana. Default-deny policy engine, spending limits, kill switch
 
 ## DeFi & Trading
 


### PR DESCRIPTION
Adds [WAIaaS](https://waiaas.ai) — a self-hosted wallet daemon for AI agents.

- **Multi-chain**: EVM + Solana unified API
- **59+ MCP tools**: wallet management, DeFi, NFT, x402, ERC-4337
- **Security**: default-deny policy engine, spending limits, human approval, kill switch
- **Self-hosted**: runs locally, no third-party API keys

GitHub: https://github.com/minhoyoo-iotrust/WAIaaS