### PR TITLE
docs: add official infrastructure MCP entries

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Hive Intelligence
+    url: https://hiveintelligence.xyz
+    about: Use this for Hive product questions that are not about the awesome list.

--- a/.github/ISSUE_TEMPLATE/server-nomination.yml
+++ b/.github/ISSUE_TEMPLATE/server-nomination.yml
@@ -1,0 +1,96 @@
+name: Nominate a crypto MCP server
+description: Suggest a maintained MCP server, adapter, or MCP-compatible crypto tool surface.
+title: "Add: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for suggestions that are not ready as a pull request yet. This list is intentionally selective, so include enough evidence for maintainers to verify the MCP surface and agent use case.
+  - type: input
+    id: project_url
+    attributes:
+      label: Project URL
+      description: Link to the official repository, documentation, package, or hosted MCP page.
+      placeholder: https://github.com/org/project
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Best category
+      options:
+        - Broad Crypto Intelligence
+        - Blockchain Data Infrastructure
+        - EVM and Smart Contracts
+        - Solana
+        - Bitcoin and Lightning
+        - Layer-1 and Cross-Chain
+        - DeFi, Markets, and Trading
+        - Prediction Markets
+        - Security and Risk
+        - News, Sentiment, and Research Signals
+        - Agent Wallets and On-chain Actions
+        - Related Lists and Directories
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: mcp_evidence
+    attributes:
+      label: MCP evidence
+      description: Link to the MCP docs, server entrypoint, package, hosted endpoint, client config, or tool catalog.
+      placeholder: "Example: npm package, server.json, docs page, transport mode, tool list."
+    validations:
+      required: true
+  - type: textarea
+    id: agent_use_case
+    attributes:
+      label: Agent use case
+      description: What should an AI agent use this server for?
+      placeholder: "Example: query Solana wallet activity, deploy nodes, inspect DEX pools, fetch security labels."
+    validations:
+      required: true
+  - type: input
+    id: install_or_connect
+    attributes:
+      label: Install or connection path
+      description: Include the safest known install command, hosted URL, or client configuration path.
+      placeholder: "npx package@latest, https://example.com/mcp, Docker image, or docs URL."
+    validations:
+      required: false
+  - type: textarea
+    id: maintenance_signals
+    attributes:
+      label: Maintenance signals
+      description: Recent commits, official provider ownership, docs quality, adoption, package status, or security posture.
+    validations:
+      required: true
+  - type: dropdown
+    id: risk_surface
+    attributes:
+      label: Risk surface
+      options:
+        - Read-only data or documentation
+        - API key required
+        - Wallet, signing, or private-key handling
+        - Trading or order execution
+        - Infrastructure/admin mutations
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: risk_docs
+    attributes:
+      label: Risk documentation
+      description: Link to docs that explain credentials, permissions, signing, trading, or write operations if relevant.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Final checks
+      options:
+        - label: I checked that this project is not already listed.
+          required: true
+        - label: I did not include secrets, API keys, private keys, seed phrases, or private customer data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml
+++ b/.github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml
@@ -1,0 +1,54 @@
+name: Report a stale, broken, or unsafe entry
+description: Flag entries that are unavailable, misleading, unmaintained, deprecated, or unsafe.
+title: "Review: "
+body:
+  - type: input
+    id: entry_name
+    attributes:
+      label: Entry name
+      placeholder: Hive Intelligence
+    validations:
+      required: true
+  - type: input
+    id: entry_url
+    attributes:
+      label: Entry URL
+      placeholder: https://github.com/org/project
+    validations:
+      required: true
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: What changed?
+      options:
+        - Broken link
+        - Archived or unmaintained
+        - Deprecated package or endpoint
+        - Missing or unclear MCP interface
+        - Unsafe wallet, signing, trading, or key handling
+        - Misleading description
+        - Duplicate or wrong category
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link to the relevant page, commit, archive notice, failed install, security note, or replacement docs.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_action
+    attributes:
+      label: Suggested action
+      description: Should this be updated, moved, marked stale, or removed?
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I did not include secrets, API keys, private keys, seed phrases, or private customer data.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ Descriptions should explain what the server actually helps an agent do. Avoid hy
 - The project has been checked for an MCP interface and basic maintenance signals.
 - Write, trading, wallet, or signing tools are described with the right level of risk.
 
+## Issue Triage
+
+Use the server nomination issue form when a project looks promising but is not ready for a pull request. Include links to the MCP surface, install or connection path, maintenance signals, and any credential, signing, trading, or write-operation risk.
+
+Use the stale or unsafe entry issue form when an existing listing is broken, archived, deprecated, misleading, duplicated, or missing a clear MCP interface. Include evidence and a suggested action so maintainers can update or remove it quickly.
+
 ## Maintenance Notes
 
 Maintainers may reorder entries by usefulness, official backing, maintenance quality, and category fit. Projects can be removed if they become stale, unsafe, unavailable, or misleading.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ If you are building an AI agent that needs crypto intelligence, start with the s
 
 **Official Blockchain API access:** Start with Alchemy MCP Server for hosted OAuth access to token prices, multichain balances, transfers, NFTs, smart accounts, and swaps.
 
+**Blockchain node and endpoint operations:** Start with Chainstack MCP or Quicknode MCP when the agent needs remote node deployment, endpoint management, platform status, docs search, or live RPC workflows.
+
 **Multi-package Blockchain API suite:** Start with Crypto APIs MCP Servers for hosted HTTP or package-level stdio access to balances, blocks, transactions, fees, events, contracts, market data, HD wallets, signing, simulation, and transaction preparation.
 
-**Blockchain trading datasets:** Start with Bitquery MCP Server when the agent needs hosted access to Bitquery's blockchain, DEX, token, and trading datasets.
+**Blockchain trading datasets:** Start with Bitquery MCP Server when the agent needs hosted access to Bitquery's Blockchain, DEX, token, and trading datasets.
 
 **Direct EVM chain actions:** Start with EVM MCP Server for contract calls, ENS, transfers, and multi-network support.
 
@@ -44,6 +46,8 @@ If you are building an AI agent that needs crypto intelligence, start with the s
 **Subgraph intelligence:** Start with Subgraph MCP Server when the agent needs to discover schemas and query The Graph Network subgraphs.
 
 **Official Solana developer help:** Start with Solana MCP Official for documentation, expert help, and developer workflows.
+
+**Production Solana APIs:** Start with Helius MCP Server for Solana RPC, DAS, transfers, webhooks, streaming, wallet analysis, priority fees, onboarding, and docs.
 
 **BNB Chain development:** Start with BNBChain MCP for BSC, opBNB, Greenfield, token, contract, wallet, and ERC-8004 agent identity workflows.
 
@@ -70,7 +74,9 @@ If you are building an AI agent that needs crypto intelligence, start with the s
 ## Blockchain Data Infrastructure
 
 - [Alchemy MCP Server](https://github.com/alchemyplatform/alchemy-mcp-server) - Official Alchemy MCP with hosted Streamable HTTP/OAuth and local stdio for token prices, multichain balances, transfers, NFTs, smart accounts, and swaps.
-- [Bitquery MCP Server](https://docs.bitquery.io/docs/mcp/mcp-server/) - Hosted Bitquery MCP endpoint for blockchain, DEX, token, and trading datasets used across Bitquery's GraphQL, streaming, and analytics products.
+- [Chainstack MCP Server](https://docs.chainstack.com/docs/chainstack-mcp-server) - Official remote Streamable HTTP MCP for documentation search, platform status, live RPC queries, node deployment, faucet requests, pricing, and Chainstack project management across 70+ chains.
+- [Quicknode MCP](https://www.quicknode.com/docs/build-with-ai/quicknode-mcp) - Official remote OAuth MCP for Quicknode account operations, endpoint management, usage monitoring, security settings, billing review, and API-aware agent workflows.
+- [Bitquery MCP Server](https://docs.bitquery.io/docs/mcp/mcp-server/) - Hosted Bitquery MCP endpoint for Blockchain, DEX, token, and trading datasets used across Bitquery's GraphQL, streaming, and analytics products.
 - [Crypto APIs MCP Servers](https://github.com/CryptoAPIs-io/cryptoapis-mcp-hub) - Official Crypto APIs MCP suite with a hosted Streamable HTTP endpoint and package-level servers for balances, blocks, transactions, fees, events, contracts, market data, HD wallets, signing, simulation, and transaction preparation.
 - [GoldRush MCP Server](https://goldrush.dev/docs/goldrush-mcp-server) - Covalent GoldRush MCP for multichain wallet balances, token holdings, transaction histories, chain metadata, and standardized Blockchain data tools.
 - [Nodit MCP Server](https://github.com/noditlabs/nodit-mcp-server) - Structured multi-chain Blockchain data through Nodit's Web3 Data and Node APIs.
@@ -93,6 +99,7 @@ If you are building an AI agent that needs crypto intelligence, start with the s
 ## Solana
 
 - [Solana MCP Official](https://github.com/solana-foundation/solana-mcp-official) - Official Solana developer MCP for documentation search, expert help, and program autofix workflows.
+- [Helius MCP Server](https://www.helius.dev/docs/helius-mcp) - Official Helius MCP with 60+ Solana tools across DAS, RPC, transfers, webhooks, streaming, wallet analysis, priority fees, onboarding, and docs.
 - [SendAI Solana MCP](https://github.com/sendaifun/solana-mcp) - Solana Agent Kit powered MCP for interacting with the Solana Blockchain.
 - [OpenSVM Solana MCP Server](https://github.com/openSVM/solana-mcp-server) - Rust-based Solana MCP focused on RPC methods.
 - [Jupiter MCP](https://github.com/kukapay/jupiter-mcp) - Solana swap MCP using Jupiter's Ultra API.


### PR DESCRIPTION
## Summary
- Add official Chainstack, Quicknode, and Helius MCP entries to keep the list current with top provider-backed infrastructure surfaces.
- Add Start Here guidance for blockchain node/endpoint operations and production Solana API workflows.
- Add issue forms for server nominations and stale, broken, or unsafe entry reports so curation can compound without lowering the quality bar.

## Research basis
- Chainstack docs: https://docs.chainstack.com/docs/chainstack-mcp-server
- Quicknode docs: https://www.quicknode.com/docs/build-with-ai/quicknode-mcp
- Helius docs: https://www.helius.dev/docs/helius-mcp
- Helius npm package: helius-mcp@1.3.0

## Verification
- git diff --check HEAD~2..HEAD
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/server-nomination.yml .github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml
- npx --yes markdown-link-check README.md

Note: local awesome-lint reports remark-lint:awesome-github before the branch exists as a remote PR; CI should validate the branch in GitHub context.