### PR TITLE
ci: add README link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,33 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - README.md
+      - CONTRIBUTING.md
+      - SUBMISSIONS.md
+      - .github/workflows/link-check.yml
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - CONTRIBUTING.md
+      - SUBMISSIONS.md
+      - .github/workflows/link-check.yml
+  schedule:
+    - cron: "23 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  readme-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npx --yes markdown-link-check README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Descriptions should explain what the server actually helps an agent do. Avoid hy
 - The description is one sentence and ends with punctuation.
 - The repository link is not already listed.
 - The project has been checked for an MCP interface and basic maintenance signals.
+- README links pass `npx --yes markdown-link-check README.md`.
 - Write, trading, wallet, or signing tools are described with the right level of risk.
 
 ## Issue Triage


### PR DESCRIPTION
## Summary
- Add a dedicated Link Check workflow for README links on pull requests, main pushes, weekly schedule, and manual dispatch.
- Add the local markdown-link-check command to the contributor checklist.

## Why
A curated awesome list compounds only if stale links are caught early. This gives us an automated maintenance gate beyond awesome-lint.

## Verification
- git diff --check HEAD~1..HEAD
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/link-check.yml"); puts "workflow yaml ok"'
- npx --yes markdown-link-check README.md