### PR TITLE
ci: update GitHub actions to v6

### DIFF
--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -13,8 +13,8 @@ jobs:
   awesome-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npx --yes awesome-lint

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,8 +28,8 @@ jobs:
   readme-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npx --yes markdown-link-check README.md


### PR DESCRIPTION
## Summary
- Update actions/checkout and actions/setup-node from v4 to v6 in both maintenance workflows.
- Removes the Node 20 deprecation warning shown by GitHub Actions after the latest Link Check run.

## Verification
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/awesome-lint.yml .github/workflows/link-check.yml

Latest official release tags checked with GitHub API:
- actions/checkout: v6.0.2
- actions/setup-node: v6.4.0