### PR TITLE
Label curation issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/server-nomination.yml
+++ b/.github/ISSUE_TEMPLATE/server-nomination.yml
@@ -1,6 +1,7 @@
 name: Nominate a crypto MCP server
 description: Suggest a maintained MCP server, adapter, or MCP-compatible crypto tool surface.
 title: "Add: "
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml
+++ b/.github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml
@@ -1,6 +1,7 @@
 name: Report a stale, broken, or unsafe entry
 description: Flag entries that are unavailable, misleading, unmaintained, deprecated, or unsafe.
 title: "Review: "
+labels: ["bug"]
 body:
   - type: input
     id: entry_name


### PR DESCRIPTION
## Summary\n- keeps the existing curation issue forms intact\n- applies existing GitHub labels to nomination and stale-entry reports so triage is cleaner\n\n## Verification\n- git diff --check\n- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} ok" }' .github/ISSUE_TEMPLATE/server-nomination.yml .github/ISSUE_TEMPLATE/stale-or-unsafe-entry.yml