### PR TITLE
ci: check contributing links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -34,4 +34,5 @@ jobs:
           node-version: 22
       - run: npx --yes markdown-link-check README.md
       - run: npx --yes markdown-link-check llms.txt
+      - run: npx --yes markdown-link-check CONTRIBUTING.md
       - run: npx --yes markdown-link-check SUBMISSIONS.md


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md to the scheduled and PR link-check command list.
- Keeps the workflow aligned with its existing path trigger so contributor-guide links are actually validated.

## Validation
- git diff --check
- npx --yes markdown-link-check README.md
- npx --yes markdown-link-check llms.txt
- npx --yes markdown-link-check CONTRIBUTING.md
- npx --yes markdown-link-check SUBMISSIONS.md
- npx --yes awesome-lint