### PR TITLE
docs: add MCP directory resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,11 +702,13 @@ This list is ordered for agent usefulness, not sponsorship, GitHub stars, or key
 - [Kukapay MCP Servers](https://github.com/kukapay/kukapay-mcp-servers) - Crypto MCP suite index covering DeFi, DEX, market data, news, on-chain analysis, bridges, NFTs, and utilities.
 - [Awesome Lists](https://github.com/szabgab/awesome-lists) - General index of awesome lists across domains.
 - [MCP Registry](https://registry.modelcontextprotocol.io/) - Official MCP server registry for production server discovery.
+- PulseMCP (`pulsemcp[.]com`) - Large MCP server directory, newsletter, API, and partner registry surface that ingests from the Official MCP Registry.
 - [MCP.Directory](https://mcp.directory/) - Broad MCP directory with server pages, category pages, publisher pages, and client install surfaces.
 - [MCP Catalogs](https://mcpcatalogs.com/en) - Independent bilingual MCP directory with AI-evaluated server pages and side-by-side comparison.
 - [MCPRepository](https://mcprepository.com/) - MCP server directory with GitHub-indexed server pages, search, and an npm-backed submission CLI.
 - [MCPpedia](https://mcppedia.org/) - Open MCP catalog with server scoring, security signals, community submissions, API access, and daily official-registry sync.
 - [MCP Showcase](https://mcpshowcase.com/p/mcp-server-directory) - Interactive MCP server directory and playground pages for testing and presenting MCP endpoints.
+- [MCP Server Spot](https://www.mcpserverspot.com/) - Modern MCP server directory with category pages, server detail pages, structured metadata, and a public submit flow.
 - [MCP Bundles](https://www.mcpbundles.com/) - MCP marketplace and bundling directory with provider pages, publish flow, and SKILL.md-oriented discovery.
 - [MCP.so](https://mcp.so/) - Large community MCP directory with indexed server pages, category browsing, and search traffic around Claude MCP and Awesome MCP Servers.
 - [FindMCP](https://findmcp.dev/) - Large web MCP directory with category pages, server search, and an MCP installer companion CLI.

--- a/llms.txt
+++ b/llms.txt
@@ -259,11 +259,13 @@ Start with read-only MCPs for research and due diligence. Escalate to API-key or
 - [MCP Registry](https://registry.modelcontextprotocol.io/): Official MCP server registry for production server discovery.
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers): Large cross-category MCP server directory.
 - [Awesome Lists](https://github.com/szabgab/awesome-lists): General index of awesome lists across domains.
+- PulseMCP (`pulsemcp[.]com`): Large MCP server directory, newsletter, API, and partner registry surface that ingests from the Official MCP Registry.
 - [MCP.Directory](https://mcp.directory/): Broad MCP directory with server pages, category pages, publisher pages, and client install surfaces.
 - [MCP.so](https://mcp.so/): Large community MCP directory with indexed server pages, category browsing, and search traffic around Claude MCP and Awesome MCP Servers.
 - [MCPRepository](https://mcprepository.com/): MCP server directory with GitHub-indexed server pages, search, and an npm-backed submission CLI.
 - [MCPpedia](https://mcppedia.org/): Open MCP catalog with server scoring, security signals, community submissions, API access, and daily official-registry sync.
 - [MCP Showcase](https://mcpshowcase.com/p/mcp-server-directory): Interactive MCP server directory and playground pages for testing and presenting MCP endpoints.
+- [MCP Server Spot](https://www.mcpserverspot.com/): Modern MCP server directory with category pages, server detail pages, structured metadata, and a public submit flow.
 - [MCP Bundles](https://www.mcpbundles.com/): MCP marketplace and bundling directory with provider pages, publish flow, and SKILL.md-oriented discovery.
 - [FindMCP](https://findmcp.dev/): Large web MCP directory with category pages, server search, and an MCP installer companion CLI.
 - [MCPList.ai](https://www.mcplist.ai/): Broad MCP directory with verified/community server browsing, function categories, comparison content, and a contact-based contribution path.


### PR DESCRIPTION
## Summary\n- add PulseMCP to related MCP discovery resources without a clickable URL because it fails automated link checks\n- add MCP Server Spot to README and llms.txt after verifying the live directory and Hive listing\n\n## Verification\n- npx --yes markdown-link-check README.md\n- npx --yes markdown-link-check llms.txt\n- npx --yes awesome-lint