### PR TITLE
docs: define curation maintenance standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,4 +60,12 @@ Use the stale or unsafe entry issue form when an existing listing is broken, arc
 
 ## Maintenance Notes
 
-Maintainers may reorder entries by usefulness, official backing, maintenance quality, and category fit. Projects can be removed if they become stale, unsafe, unavailable, or misleading.
+Maintainers may reorder entries by usefulness, official backing, maintenance quality, and category fit. Projects can be removed if they become stale, unsafe, unavailable, duplicated, or misleading.
+
+When reviewing existing entries, check:
+
+- The linked page still resolves and still documents an MCP server, adapter, or compatible tool surface.
+- The install or connection path is still plausible for an MCP client.
+- The project has recent maintenance, official backing, meaningful adoption, or still-relevant documentation.
+- Credential, wallet, trading, signing, write, or infrastructure-admin risk is explained clearly enough for an agent to route safely.
+- The entry is still the best available representative for its category and does not duplicate a stronger official or maintained server.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Last curated: 2026-06-01.
 - [Selection Criteria](#selection-criteria)
 - [Risk Routing](#risk-routing)
 - [Curation Priority](#curation-priority)
+- [Maintenance Standard](#maintenance-standard)
 - [Broad Crypto Intelligence](#broad-crypto-intelligence)
 - [Blockchain Data Infrastructure](#blockchain-data-infrastructure)
 - [EVM and Smart Contracts](#evm-and-smart-contracts)
@@ -519,6 +520,16 @@ This list is ordered for agent usefulness, not sponsorship, GitHub stars, or key
 - Prefer narrow, source-specific MCPs when the user asks for a specific chain, exchange, wallet, data provider, bridge, or protocol.
 - Prefer read-only and documentation/search surfaces for research and due diligence. Escalate to write, trade, wallet, signing, staking, or infrastructure-admin tools only when the task clearly requires them.
 - Keep entries out, or remove them later, when the MCP interface is unclear, install paths are broken, maintenance stops, the project becomes misleading, or the risk model is not documented.
+
+## Maintenance Standard
+
+This is a curated list, not an add-only catalog. Entries should stay useful to an agent choosing a crypto MCP server today.
+
+- Recheck links and basic Markdown quality in CI, including `README.md`, `llms.txt`, `CONTRIBUTING.md`, and `SUBMISSIONS.md`.
+- Prefer primary docs, official repos, MCP Registry entries, or maintained package pages over thin mirrors and stale forks.
+- Keep descriptions use-case oriented: what the server helps an agent do, what credentials it needs, and where the risk boundary is.
+- Remove or downgrade entries when a repo is archived, install paths break, docs disappear, the MCP interface is unclear, or the project becomes unsafe.
+- Use [SUBMISSIONS.md](SUBMISSIONS.md) to track external directory status so stale Hive listings and duplicate outreach do not drift out of sight.
 
 ## Broad Crypto Intelligence
 


### PR DESCRIPTION
## Summary
- add a public README maintenance standard for the curated list
- expand contributor maintenance checks for stale, unsafe, or duplicated entries
- make the repo's anti-add-only policy visible to readers and contributors

## Research basis
- Awesome-list guidance emphasizes curation over collection and leaving weak entries out
- awesome-lint is already in use for continuous awesome-list quality checks

## Verification
- npx --yes awesome-lint
- npx --yes markdown-link-check README.md
- npx --yes markdown-link-check CONTRIBUTING.md
- git diff --check