### PR TITLE
ci: tighten curation intake checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
 - Project added or updated:
 - Category:
 - Why it belongs:
+- Official or maintenance evidence:
+- Coverage gap or stronger alternative:
 - Transport or interface:
 - Auth or credential model:
 - Risk boundary:
@@ -12,6 +14,7 @@
 - [ ] The project exposes or documents an MCP server, adapter, or MCP-compatible tool surface.
 - [ ] The project is directly relevant to crypto, Web3, DeFi, wallets, trading, Blockchain development, security, or market intelligence.
 - [ ] Installation or usage docs are available.
+- [ ] Official provider backing, MCP Registry presence, active maintenance, or meaningful adoption is clear.
 - [ ] Write, trading, wallet, or signing risks are documented if applicable.
 - [ ] The README entry is factual, concise, unique, and ends with punctuation.
 - [ ] The project materially improves the curated list and does not duplicate a stronger official or maintained entry.

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -33,6 +33,8 @@ jobs:
           abort "#{pr_template} is missing" unless File.file?(pr_template)
 
           required_prompts = [
+            "Official or maintenance evidence:",
+            "Coverage gap or stronger alternative:",
             "Transport or interface:",
             "Auth or credential model:",
             "Risk boundary:",


### PR DESCRIPTION
## Summary
- Require PR submitters to include official/maintenance evidence and the coverage gap versus existing entries.
- Extend the existing awesome-lint template guard so these curation prompts cannot drift out of the PR template.

## Verification
- git diff --check
- npx --yes awesome-lint
- npx --yes markdown-link-check .github/PULL_REQUEST_TEMPLATE.md