### PR TITLE
Add TWZRD Agent Intel — Solana-native AI agent trust scoring via x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ This is a curated list, not an add-only catalog. Entries should stay useful to a
 - [OpenSVM Solana MCP Server](https://github.com/openSVM/solana-mcp-server) - Rust-based Solana MCP focused on RPC methods.
 - [Jupiter MCP](https://github.com/kukapay/jupiter-mcp) - Solana swap MCP using Jupiter's Ultra API.
 - [Solana MCP Directory](https://github.com/sendaifun/awesome-solana-mcp-servers) - Solana-specific MCP list for deeper Solana ecosystem discovery.
+- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s.
 
 ## Bitcoin and Lightning
 

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ This is a curated list, not an add-only catalog. Entries should stay useful to a
 - [OpenSVM Solana MCP Server](https://github.com/openSVM/solana-mcp-server) - Rust-based Solana MCP focused on RPC methods.
 - [Jupiter MCP](https://github.com/kukapay/jupiter-mcp) - Solana swap MCP using Jupiter's Ultra API.
 - [Solana MCP Directory](https://github.com/sendaifun/awesome-solana-mcp-servers) - Solana-specific MCP list for deeper Solana ecosystem discovery.
-- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s.
 
 ## Bitcoin and Lightning
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz to the **Solana** section.

**Entry:**
- **[TWZRD Agent Intel](https://intel.twzrd.xyz** - Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s.

**Why it fits:**
- Solana-native (on-chain trust scoring, USDC settlement via Solana x402)
- MCP endpoint: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)
- x402 micropayment-gated signed receipts — agent-to-agent trust verification

**Placement:** Added after the existing Solana entries, before the `Solana MCP Directory` closing entry.